### PR TITLE
Fix adding custom axis labels to plot

### DIFF
--- a/R/plot.permTestResultsList.R
+++ b/R/plot.permTestResultsList.R
@@ -47,7 +47,7 @@ plot.permTestResultsList<-function(x, ncol=NA, pvalthres=0.05, plotType="Tailed"
   
   old.par <- par(mfrow=c(nrow, ncol))
   
-  lapply(x, plot, ...)
+  lapply(x, plot, pvalthres=0.05, plotType="Tailed", main="", xlab=NULL, ylab="", ...)
 
   par(mfrow=old.par)
   


### PR DESCRIPTION
Extra parameters such as labels are not passed onto the plot function, meaning you cannot change axis labels.